### PR TITLE
adds spell levels to unity unpack

### DIFF
--- a/items.go
+++ b/items.go
@@ -41,6 +41,7 @@ func DownloadItems(hashJson *ankabuffer.Manifest, bin int, version int, dir stri
 			{Filename: "Dofus_Data/StreamingAssets/Content/Data/data_assets_spellpairsroot.asset.bundle", FriendlyName: "spell_pairs.asset.bundle"},
 			{Filename: "Dofus_Data/StreamingAssets/Content/Data/data_assets_spellstatesroot.asset.bundle", FriendlyName: "spell_states.asset.bundle"},
 			{Filename: "Dofus_Data/StreamingAssets/Content/Data/data_assets_spellvariantsroot.asset.bundle", FriendlyName: "spell_variants.asset.bundle"},
+			{Filename: "Dofus_Data/StreamingAssets/Content/Data/data_assets_spelllevelsroot.asset.bundle", FriendlyName: "spell_levels.asset.bundle"},
 		}
 
 		err := DownloadUnpackFiles("Items", bin, hashJson, "data", fileNames, dir, outPath, true, indent, headless, false)

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	DodudaVersion     = "v0.5.9"
+	DodudaVersion     = "v0.5.10"
 	DodudaShort       = "doduda - Dofus data CLI"
 	DodudaLong        = "CLI for Dofus asset downloading and unpacking."
 	DodudaVersionHelp = DodudaShort + "\n" + DodudaVersion + "\nhttps://github.com/dofusdude/doduda"


### PR DESCRIPTION
## Context
Spell levels are one of the angular stones of spell data, it all basically relates to it and these were missing.